### PR TITLE
Do echo-back control using stty

### DIFF
--- a/lsix
+++ b/lsix
@@ -22,9 +22,11 @@ tileheight=$tilesize
 
 cleanup() {
     echo $'\e\\'		# Escape sequence to stop SIXEL
+    stty echo
     exit 0
 }
 trap cleanup SIGINT SIGHUP SIGABRT
+stty -echo
 
 # TERMINAL COLOR AUTODETECTION.
 # Find out how many color registers the terminal has
@@ -118,6 +120,7 @@ fi
 # Send an escape sequence and wait for a response from the terminal
 # so that the program won't quit until images have finished transferring.
 read -s -t 60 -d "c" -p $'\e[c' >&2
+stty echo
 
 
 ######################################################################


### PR DESCRIPTION
This is a little workaround for my environment.

```
$ uname -a
Darwin hsaito.local 15.6.0 Darwin Kernel Version 15.6.0: Tue Apr 11 16:00:51 PDT 2017; root:xnu-3248.60.11.5.3~1/RELEASE_X86_64 x86_64
```

- before:
<img width="903" alt="2017-06-08 1 33 55" src="https://user-images.githubusercontent.com/1162739/26889909-a7c01d56-4bea-11e7-9040-45062edfdd5c.png">

- after:
<img width="904" alt="2017-06-08 1 10 56" src="https://user-images.githubusercontent.com/1162739/26889943-c06dec3e-4bea-11e7-8913-c2f02c251365.png">