### PR TITLE
Use correct bash shebang

### DIFF
--- a/lsix
+++ b/lsix
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # lsix: like ls, but for images.
 # Shows thumbnails of images with titles directly in terminal. 


### PR DESCRIPTION
Hello,

First of all, thank you for this awesome project! 
Bash scripts should use the shebang `#!/usr/bin/env bash` for portability (See https://stackoverflow.com/a/10383546), making `lsix` fail on some systems.

This PR fixes the shebang to make `lsix` run on more *nix.