### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ to your `.Xresources` file and run `xrdb -merge .Xresources`.
 * XTerm (tested)
 * MLterm (tested)
 * WSLtty (reported)
-* MiniTTY (Cygwin) (reported)
+* mintty (Cygwin) (reported)
 
 ## Configuration
 


### PR DESCRIPTION
MinTTY is written as mintty since 2009 (https://groups.google.com/forum/#!msg/mintty-discuss/Qb_88RMRy-o/NUfct8j9dl8J).