### PR TITLE
add preliminary support for terminal multiplexers

### DIFF
--- a/lsix
+++ b/lsix
@@ -239,6 +239,16 @@ processlabel() {
 	sed 's|%|%%|g; s|\\|\\\\|g; s|@|\\@|g;'
 }
 
+muxwrap(){
+    if [ "${TERM%%.*}" == screen ] && [ -v STY ]; then
+        sed 's,.\{767\},&\o33\\\o33P,g;1s,^,\o33P,;$s,$,\o33\\,'
+    elif [ "${TERM%%.*}" == screen ] && [ -v TMUX ]; then
+        sed 's,\o33,&&,g;1s,^,\o33Ptmux;,;$s,$,\o33\\,'
+    else
+        sed b
+    fi
+}
+
 #### 
 
 main "$@"


### PR DESCRIPTION
This adds preliminary support for terminal multiplexers (tmux, screen).

Escape codes meant for the terminal have to be piped through muxwrap. Positional escape codes probably should be directed to the multiplexer.

You can test the function in a sixel capable terminal with and without tmux/screen like this:

```
printf '\033Pq#0;2;0;0;0#1;2;100;100;0#2;2;0;100;0#1~~@@vv@@~~@@~~$#2??}}GG}}??}}??-#1!14@\033\\' | muxwrap
```

The functionality of lsix is unchanged and you have to figure out where to wrap the escape codes.

I needed this for https://github.com/gizak/termui/pull/233 - thought this could help here too.