### PR TITLE
Foot has (since version 1.8.2) reversed the meaning of DECSDM

### DIFF
--- a/lsix
+++ b/lsix
@@ -112,7 +112,7 @@ autodetect() {
     fi
 
     # ENABLE SIXEL SCROLLING so image will appear right after cursor.
-    if [[ $TERM != "mlterm" ]]; then
+    if [[ $TERM != "mlterm" ]] && [[ $TERM != "foot" ]]; then
 	echo -ne $'\e[?80h'
     else
 	# Except... mlterm (as of 3.5.0) has a bug that reverses the sense


### PR DESCRIPTION
In https://github.com/hackerb9/lsix/issues/41, it was shown that enabling DECSDM, disables sixel scrolling. Something many terminals, including foot, has gotten wrong.

In 1.8.2 this was changed in foot, so that setting DECSDM now disables scrolling. Thus, lsix needs to emit \E[?80l, not \E[?80h.

Note: I guess we could start checking terminal version numbers, but thought that would just complicate the script unnecessarily. Also, I realize this is something that you may want to re-write in the future, if more terminals follow. So I opted for a small change, to make sure lsix works properly on latest foot.