### PR TITLE
Windowsconvert

### DIFF
--- a/lsix
+++ b/lsix
@@ -63,6 +63,12 @@ if command -v gsed >/dev/null; then
     alias sed=gsed		# Use GNU sed for MacOS & BSD
 fi
 
+if [[ "$COMSPEC" ]]; then	# Workaround MS Windows' "convert" command.
+    temp=$(type -P montage) 		# Use the montage binary to 
+    temp=${temp%montage}convert		# find ImageMagick's convert.
+    alias convert=\"${temp}\" 		# Quotes for potential spaces.
+fi
+
 cleanup() {
     echo -n $'\e\\'		# Escape sequence to stop SIXEL.
     stty echo			# Reset terminal to show characters.

--- a/lsix
+++ b/lsix
@@ -59,18 +59,16 @@ if ! command -v montage >/dev/null; then
     exit 1
 fi
 
-shopt -s expand_aliases		# Allow aliases to work around quirks
+shopt -s expand_aliases		# Allow aliases for working around quirks.
 
 if command -v gsed >/dev/null; then
-    alias sed=gsed		# Use GNU sed for MacOS & BSD
+    alias sed=gsed		# Use GNU sed for MacOS & BSD.
 fi
 
-if [[ "$COMSPEC" ]]; then	# Workaround MS Windows' "convert" command.
-    temp=$(type -P montage) 		# Use the montage binary to 
-    temp=${temp%montage}convert		# find ImageMagick's convert.
-    alias convert=\"${temp}\" 		# Quotes for potential spaces.
+if [[ "$COMSPEC" ]]; then
+    alias convert="magick convert" # Shun MS Windows' "convert" command.
 fi
-
+    
 cleanup() {
     echo -n $'\e\\'		# Escape sequence to stop SIXEL.
     stty echo			# Reset terminal to show characters.

--- a/lsix
+++ b/lsix
@@ -59,6 +59,8 @@ if ! command -v montage >/dev/null; then
     exit 1
 fi
 
+shopt -s expand_aliases		# Allow aliases to work around quirks
+
 if command -v gsed >/dev/null; then
     alias sed=gsed		# Use GNU sed for MacOS & BSD
 fi


### PR DESCRIPTION
WIndows PATH order fix so that we never run Microsoft's "convert" program. 

Once merged, this will close #42.