### PR TITLE
Handle files with leading at signs, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,13 +167,6 @@ GitHub.
   will be removed once xterm can handle images greater than 1000x1000.
   [Last tested with XTerm(344)].
 
-* Filenames that begin with "@" are special to ImageMagick and it'll
-  freak out if you don't prepend a directory. (`lsix ./@foo.png`)
-  (This is a bug in ImageMagick, not lsix).
-
-* Specifying the empty string `""` as a filename makes ImageMagick hang.
-  (This appears to be an ImageMagick bug / misfeature). 
-
 * Long filenames are wrapped, but not intelligently. Would it
   complicate this script too much to make it prefer to wrap on whites
   space, dashes, underscores, and periods? Maybe.

--- a/lsix
+++ b/lsix
@@ -234,12 +234,17 @@ main() {
 	    len=${#onerow[@]}
 	    onerow[len++]="-label"
 	    onerow[len++]=$(processlabel "$1")
-	    onerow[len++]="file://$1"
+      onerow[len++]="file://$(imescape $1)"
 	    shift
 	done
-	montage "${onerow[@]}"  $imoptions gif:-  \
+
+  montage "${onerow[@]}"  $imoptions gif:-  \
 	    | convert - -colors $numcolors sixel:-
     done
+}
+
+imescape() {
+    echo "$@" | sed -e 's|^@|./@|g;'
 }
 
 processlabel() {


### PR DESCRIPTION
The bit about empty strings no longer appears to be the case, at least with ImageMagick 6.9.11-60. Update README. When supplied an initial '@', prefix it with './' to work around another IM issue. Update README.