### PR TITLE
Workaround the cursor placement bug

### DIFF
--- a/lsix
+++ b/lsix
@@ -120,6 +120,19 @@ autodetect() {
     # SIXEL SCROLLING (~DECSDM) is now presumed to be enabled.
     # See https://github.com/hackerb9/lsix/issues/41 for details.
 
+    # SIXEL CURSOR PLACEMENT BUG WORKAROUND
+    case "$TERM" in
+	vt340*|contour*)
+	    # These terminals are correct. 
+	    sixelcursorbug=""	
+	    ;;
+	xterm*|mlterm|yaft*|*)
+	    # These terminals have not yet been fixed.
+	    sixelcursorbug="-n"	
+	    ;;
+    esac
+
+
     # TERMINAL COLOR AUTODETECTION.
     # Find out how many color registers the terminal has
     IFS=";"  read -a REPLY -s -t ${timeout} -d "S" -p $'\e[?1;1;0S' >&2
@@ -243,6 +256,8 @@ main() {
 	done
 	montage "${onerow[@]}"  $imoptions gif:-  \
 	    | convert - -colors $numcolors sixel:-
+
+	echo $sixelcursorbug	# Go to next line, unless terminal is quirky.
     done
 }
 

--- a/lsix
+++ b/lsix
@@ -127,11 +127,10 @@ autodetect() {
 	    sixelcursorbug=""	
 	    ;;
 	xterm*|mlterm|yaft*|*)
-	    # These terminals have not yet been fixed.
+	    # These terminals have not yet been fixed. Use -n for echo.
 	    sixelcursorbug="-n"	
 	    ;;
     esac
-
 
     # TERMINAL COLOR AUTODETECTION.
     # Find out how many color registers the terminal has
@@ -254,10 +253,15 @@ main() {
 	    onerow[len++]="file://$1"
 	    shift
 	done
-	montage "${onerow[@]}"  $imoptions gif:-  \
-	    | convert - -colors $numcolors sixel:-
+	output=$(montage "${onerow[@]}"  $imoptions gif:-  \
+		     | convert - -colors $numcolors sixel:-)
 
-	echo $sixelcursorbug	# Go to next line, unless terminal is quirky.
+	# Workaround bug in ImageMagick that erroneously sends a
+	# graphics newline (-) before the end of the image (Esc backslash).
+	output=${output%-??}$'\e\\'
+
+	# Go to next line, unless terminal is quirky.
+	echo $sixelcursorbug "$output"
     done
 }
 


### PR DESCRIPTION
It has been pointed out by @j4james that, in correct sixel implementations, the text cursor after showing a sixel image should overlap with the bottom of the image. It seems likely that terminal emulators will gradually change to reflect that as that is how a full screen sixel image can be shown without scrolling. There are also subtle problems that occur with different heights of sixel images. See:
* [cursor_position.sh](https://github.com/hackerb9/vt340test/j4james/cursor_position.sh)<br/><img src="https://raw.githubusercontent.com/hackerb9/vt340test/main/j4james/cursor_position.png" width=25%>
* [textcursor.sh](https://github.com/hackerb9/vt340test/sixeltests/textcursor.sh)<br/><img src="https://raw.githubusercontent.com/hackerb9/vt340test/main/sixeltests/textcursor.png" width=25%>

This patch checks `$TERM` and adds a text newline if the terminal is known to have a correct sixel implementation. Otherwise, it is presumed the terminal will be adding its own newline. 

Relatedly, this patch also removes the _graphics_ newline that is appended to the end of sixel images generated by ImageMagick. Again, @j4james has helped by explaining that the final graphics newline is actually harmful as it can cause the terminal to scroll on a fullscreen image. It can also be difficult for a program like lsix to tell whether a text newline is necessary or not. I believe ImageMagick and libsixel will eventually be updated to remove the final graphics newline. By doing it ourselves now, lsix is prepared for that transition and also avoids the question of extra space between rows of tiles when we send a text newline.
