### PR TITLE
Improve compatibility with ImageMagick 7

### DIFF
--- a/lsix
+++ b/lsix
@@ -68,7 +68,12 @@ fi
 if [[ "$COMSPEC" ]]; then
     alias convert="magick convert" # Shun MS Windows' "convert" command.
 fi
-    
+
+# convert has been deprecated with ImageMagick 7
+if [ "$(identify -version | head -n 1 | awk '{print $3}' | cut -d'.' -f1)" -ge 7 ]; then
+    alias convert="magick"
+fi
+
 cleanup() {
     echo -n $'\e\\'		# Escape sequence to stop SIXEL.
     stty echo			# Reset terminal to show characters.


### PR DESCRIPTION
The convert command has been deprecated starting from ImageMagick 7.
Attempting to use the script results in something like this:
![image](https://github.com/hackerb9/lsix/assets/53372753/202ae14e-5de8-4325-a938-0ddedb7bc142)

This patch checks for the ImageMagick version and uses the new command if the major version is greater or equal to 7.
After applying it, the warnings are no more:
![image](https://github.com/hackerb9/lsix/assets/53372753/a1801842-6529-49a6-b0f0-0b2b69cc4a27)

Fixes #71
Fixes #77 