### PR TITLE
✨ add a GitHub Action for shellcheck'ing on every PR and push to master branch + shellcheck'ed script

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,63 @@
+name: Shellcheck Lint
+
+on:
+  push:
+    paths:
+      # Run workflow on every push
+      # only if a file within the specified paths has been changed:
+      - 'lsix'
+
+  pull_request:
+    paths:
+      # Run workflow on every push
+      # only if a file within the specified paths has been changed:
+      - 'lsix'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Shellcheck Lint
+
+    # This job runs on Linux
+    runs-on: ubuntu-latest
+
+    steps:
+      # Required to access files of this repository
+      - uses: actions/checkout@v4
+
+      # Download Shellcheck and add it to the workflow path
+      - name: Download Shellcheck
+        run: |
+          wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv
+          chmod +x shellcheck-stable/shellcheck
+      # Verify that Shellcheck can be executed
+      - name: Check Shellcheck Version
+        run: |
+          shellcheck-stable/shellcheck --version
+
+      # Run Shellcheck on repository
+      # ---
+      # https://github.com/koalaman/shellcheck
+      # ---
+      # Excluded checks:
+      # https://www.shellcheck.net/wiki/SC1091 -- Not following: /etc/rc.status was...
+      # https://www.shellcheck.net/wiki/SC1090 -- Can't follow non-constant source. ..
+      # ---
+      - name: Run Shellcheck
+        run: |
+          set +e
+          find  ./*/ -type f | while read -r sh; do
+            if [ "$(file --brief --mime-type "$sh")" == 'text/x-shellscript' ]; then
+              echo "shellcheck'ing $sh"
+              if ! shellcheck-stable/shellcheck --color=always --severity=warning --exclude=SC1091,SC1090 "$sh"; then
+                touch some_scripts_have_failed_shellcheck
+              fi
+            fi
+          done
+          if [ -f ./some_scripts_have_failed_shellcheck ]; then
+            echo "Shellcheck failed for one or more shellscript(s)"
+            exit 1
+          fi
+

--- a/lsix
+++ b/lsix
@@ -191,6 +191,9 @@ main() {
 	readarray -t < <(printf "%s\n" "$@" | sort)
 
 	# Only show first frame of animated GIFs if filename not specified.
+  # INFO: Next two lines are only needed for shellcheck to avoid this error-messages that we can't fix right now:
+  # SC2068 (error): Double quote array expansions to avoid re-splitting elements.
+  # shellcheck disable=SC2068
 	for x in ${!MAPFILE[@]}; do
 	    if [[ ${MAPFILE[$x]} =~ (gif|webp)$ ]]; then
 		MAPFILE[$x]="${MAPFILE[$x]}[0]"
@@ -203,17 +206,13 @@ main() {
 	for arg; do
 	    if [ -d "$arg" ]; then
 		echo Recursing on $arg
-		(cd "$arg"; $lsix)
+		(cd "$arg" && $lsix)
 	    else
 		nodirs+=("$arg")
 	    fi
 	done
 	set -- "${nodirs[@]}"
     fi
-
-
-    # Resize on load: Save memory by appending this suffix to every filename.
-    resize="[${tilewidth}x${tileheight}]"
 
     imoptions="-tile ${numtiles}x1" # Each montage is 1 row x $numtiles columns
     imoptions+=" -geometry ${tilewidth}x${tileheight}>+${tilexspace}+${tileyspace}" # Size of each tile and spacing
@@ -232,7 +231,7 @@ main() {
 	# While we still have images to process...
 	onerow=()
 	goal=$(($# - numtiles)) # How many tiles left after this row
-	while [ $# -gt 0  -a  $# -gt $goal ]; do
+	while [[  $# -gt 0  &&  $# -gt $goal  ]]; do
 	    len=${#onerow[@]}
 	    onerow[len++]="-label"
 	    onerow[len++]=$(processlabel "$1")


### PR DESCRIPTION
`shellcheck` was complaining:
```
$ docker run --rm -v "$PWD:/mnt" koalaman/shellcheck:stable -Calways -S warning lsix

In lsix line 196:
	for x in ${!MAPFILE[@]}; do
                 ^------------^ SC2068 (error): Double quote array expansions to avoid re-splitting elements.


In lsix line 208:
		(cd "$arg"; $lsix)
                 ^-------^ SC2164 (warning): Use 'cd ... || exit' or 'cd ... || return' in case cd fails.

Did you mean:
		(cd "$arg" || exit; $lsix)


In lsix line 218:
    resize="[${tilewidth}x${tileheight}]"
    ^----^ SC2034 (warning): resize appears unused. Verify use (or export if used externally).


In lsix line 237:
	while [ $# -gt 0  -a  $# -gt $goal ]; do
                          ^-- SC2166 (warning): Prefer [ p ] && [ q ] as [ p -a q ] is not well defined.

For more information:
  https://www.shellcheck.net/wiki/SC2068 -- Double quote array expansions to ...
  https://www.shellcheck.net/wiki/SC2034 -- resize appears unused. Verify use...
  https://www.shellcheck.net/wiki/SC2164 -- Use 'cd ... || exit' or 'cd ... |...
```

This PR fixed this and I tested it:
<img width="584" alt="image" src="https://github.com/hackerb9/lsix/assets/18568381/d2ab589d-1951-429b-a429-31182511e06a">

My GitHub Action's Run can be found [here](https://github.com/thomasmerz/fork-lsix/actions/runs/9415055994).