### PR TITLE
Fix ImageMagick 6/7 compatibility

### DIFF
--- a/lsix
+++ b/lsix
@@ -54,7 +54,13 @@ if [[ ${BASH_VERSINFO[0]} -eq 3 ]]; then
     fi
 fi
 
-magick=$(type -p magick)	# For ImageMagick 6 <-> 7 compatibility.
+# For ImageMagick 6 <-> 7 compatibility.
+magick=$(type -p magick)	
+if [[ ! $magick ]]; then
+	convert="convert"
+else 
+	convert="$magick"
+fi
 
 if ! command -v $magick montage >/dev/null; then
     echo "Please install ImageMagick" >&2
@@ -101,7 +107,7 @@ autodetect() {
 
 	You may test your terminal by viewing a single image, like so:
 
-		$magick convert  foo.jpg  -geometry 800x480  sixel:-
+		$convert foo.jpg  -geometry 800x480  sixel:-
 
 	If your terminal actually does support sixel, please file a bug
 	report at http://github.com/hackerb9/lsix/issues
@@ -240,7 +246,7 @@ main() {
 	    shift
 	done
 	$magick montage "${onerow[@]}"  $imoptions gif:-  \
-	    | $magick convert - -colors $numcolors sixel:-
+	    | $convert - -colors $numcolors sixel:-
     done
 }
 


### PR DESCRIPTION
Unfortunately the issue is still not fixed in the latest release. 
With ImageMagick 7 the warning gets printed both when using `convert` and `magick convert`:
![image](https://github.com/hackerb9/lsix/assets/53372753/fe26b23e-2cfe-4bd9-bdad-9a70f7e16ef6)

Since the correct way to issue the convert command seems to be using `magick` without the tool name, simply appending `magick` in front of the old command does not resolve the issue:
![image](https://github.com/hackerb9/lsix/assets/53372753/2eed5d05-11ad-4a15-9d5a-ad1e3a5b1051)

I tried to keep the changes minimal:
- Introduced a `convert` variable that is set to `$magick` if it exists, or to `convert` otherwise.
- Updated lines that used `$magick convert` to use `$convert`.

There's no brittle version parsing and the fix does not depend on other standalone tools that may be deprecated in the future.
I also made sure that the non-sixel error message prints the correct ImageMagick command.

I had to create a new PR as I did not have the permissions to re-open #73.
I hope this PR addresses the issues more effectively.